### PR TITLE
Issue19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <name>Office365 Integration</name>
   <description>Search OneDrive documents directly from XWiki. Embed Office 365 documents into XWiki pages using their URL. The app can be purchased individually or part of the XWiki Pro package. Try it free.</description>
   <properties>
-    <licensing.version>1.22</licensing.version>
+    <licensing.version>1.22.1</licensing.version>
     <!-- The list of documents that have an implicit unlimited free license. The users can view these documents without
       buying a license or getting a trial license, but they cannot edit or delete them. -->
     <xwiki.extension.licensing.publicDocuments>
@@ -107,13 +107,13 @@
       <groupId>org.xwiki.contrib.showhide</groupId>
       <artifactId>showhide-macro</artifactId>
       <type>xar</type>
-      <version>2.0.1</version>
+      <version>2.0.2</version>
     </dependency>
     <dependency>
       <groupId>com.xwiki.pdfviewer</groupId>
       <artifactId>macro-pdfviewer-ui</artifactId>
       <type>xar</type>
-      <version>2.3.3</version>
+      <version>2.4</version>
     </dependency>
   </dependencies>
   <issueManagement>

--- a/src/main/resources/Office365/DocumentList.xml
+++ b/src/main/resources/Office365/DocumentList.xml
@@ -68,8 +68,7 @@ ${services.localization.render('office365.documentlist.searchterm')}: &lt;input 
  def res = azureAuth.getGraphApiData(driveURL)
  azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
  if (res.error) {
-   def errorObj = res.error;
-   println """{{error}}${services.localization.render('office365.macro.search.error')} ${errorObj.message}{{/error}}""";
+   println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.macro.search.error'));
  }
  def counter = 0;
  for (item in res.value) {

--- a/src/main/resources/Office365/DocumentList.xml
+++ b/src/main/resources/Office365/DocumentList.xml
@@ -68,7 +68,7 @@ ${services.localization.render('office365.documentlist.searchterm')}: &lt;input 
  def res = azureAuth.getGraphApiData(driveURL)
  azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
  if (res.error) {
-   println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.macro.search.error'));
+   println azureAuth.renderErrorFromResponse(res, 'office365.macro.search.error');
  }
  def counter = 0;
  for (item in res.value) {

--- a/src/main/resources/Office365/DocumentList.xml
+++ b/src/main/resources/Office365/DocumentList.xml
@@ -67,7 +67,10 @@ ${services.localization.render('office365.documentlist.searchterm')}: &lt;input 
    println "Drive url: ${driveURL}"
  def res = azureAuth.getGraphApiData(driveURL)
  azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
- 
+ if (res.error) {
+   def errorObj = res.error;
+   println """{{error}}${services.localization.render('office365.macro.search.error')} ${errorObj.message}{{/error}}""";
+ }
  def counter = 0;
  for (item in res.value) {
    counter++;

--- a/src/main/resources/Office365/Groovy.xml
+++ b/src/main/resources/Office365/Groovy.xml
@@ -91,6 +91,7 @@ public class AzureAuth {
  def xcontext;
  def doc;
  def renderingService;
+ def localizationService;
  def request;
  def response;
 
@@ -122,7 +123,7 @@ public class AzureAuth {
 
  def renderErrorFromResponse(res, message) {
   def errorMsg = res.error.message;
-  def displayMsg = """${message} ${errorMsg}""";
+  def displayMsg = """${localizationService.render(message)} ${errorMsg}""";
   return """{{error}}${renderingService.escape(displayMsg, doc.getSyntax())}{{/error}}""";
  }
 
@@ -153,6 +154,7 @@ public class AzureAuth {
    this.response = xcontext.response;
    this.doc = doc;
    this.renderingService = Utils.getComponent(ScriptService.class, "rendering");
+   this.localizationService = Utils.getComponent(ScriptService.class, "localization");
 
    this.tenant = getConfig("tenant");
    this.azureClientID = getConfig("clientid");

--- a/src/main/resources/Office365/Groovy.xml
+++ b/src/main/resources/Office365/Groovy.xml
@@ -336,7 +336,7 @@ public class AzureAuth {
    def paramMap = request.getParameterMap()
    def params = new HashMap();
    for (key in paramMap.keySet()) {
-    params.put(key, paramMap.get(key)[0])
+    params.put(key, [paramMap.get(key)[0]])
    }
    def  authResponse = AuthenticationResponseParser.parse(new URI(requestURL), params);
    if (isAuthenticationSuccessful(authResponse)) {

--- a/src/main/resources/Office365/Groovy.xml
+++ b/src/main/resources/Office365/Groovy.xml
@@ -54,6 +54,7 @@ import org.apache.http.client.utils.*;
 import com.google.gson.Gson;
 import com.xpn.xwiki.web.Utils;
 import org.xwiki.context.Execution;
+import org.xwiki.script.service.ScriptService;
 
 
 public class AzureAuth {
@@ -89,6 +90,7 @@ public class AzureAuth {
  def xwiki;
  def xcontext;
  def doc;
+ def renderingService;
  def request;
  def response;
 
@@ -118,6 +120,12 @@ public class AzureAuth {
   debugStr += msg + "\n";
  }
 
+ def renderErrorFromResponse(res, message) {
+  def errorMsg = res.error.message;
+  def displayMsg = """${message} ${errorMsg}""";
+  return """{{error}}${renderingService.escape(displayMsg, doc.getSyntax())}{{/error}}""";
+ }
+
  def showDebug() {
   if (request.debug || forceDebug)
     return "== DEBUG ==\n\n {{{ ${debugStr} }}}"
@@ -144,6 +152,7 @@ public class AzureAuth {
    this.request = xcontext.request;
    this.response = xcontext.response;
    this.doc = doc;
+   this.renderingService = Utils.getComponent(ScriptService.class, "rendering");
 
    this.tenant = getConfig("tenant");
    this.azureClientID = getConfig("clientid");

--- a/src/main/resources/Office365/Office365Macro.xml
+++ b/src/main/resources/Office365/Office365Macro.xml
@@ -580,7 +580,7 @@ def showDriveItems(site, query) {
    azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
    if (res!=null) {
     if (res.error) {
-      println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.macro.search.error'));
+      println azureAuth.renderErrorFromResponse(res, 'office365.macro.search.error');
     }
     for (item in res.value) {
      def docName = item.name;
@@ -679,11 +679,12 @@ if (url!=null &amp;&amp; url!="") {
     azureAuth.authenticate()
     def res = azureAuth.getGraphApiData(docURL)
     if (res.error) {
-      println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.macro.search.error'));
+      println azureAuth.renderErrorFromResponse(res, 'office365.macro.search.error');
     } else {
-      embedLink = res.get("@microsoft.graph.downloadUrl")
-      def pdfViewer = """\n{{pdfviewer file="${embedLink}" width="${width}" height="${heighft}" /}}\n""";
-      println services.rendering.escape(pdfViewer, doc.getSyntax());
+      embedLink = services.rendering.escape(res.get("@microsoft.graph.downloadUrl"))
+      def escapedWidth = services.rendering.escape(width);
+      def escapedHeight = services.rendering.escape(height);
+      println """\n{{pdfviewer file="${embedLink}" width="${escapedWidth}" height="${escapedHeight}" /}}\n"""
     }
    } else {
     println """{{html clean=false}}&lt;iframe src="${embedLink}" width="${width}" height="${height}"&gt;&lt;/iframe&gt;{{/html}}"""   

--- a/src/main/resources/Office365/Office365Macro.xml
+++ b/src/main/resources/Office365/Office365Macro.xml
@@ -579,6 +579,10 @@ def showDriveItems(site, query) {
    def res = azureAuth.getGraphApiData(driveURL)
    azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
    if (res!=null) {
+    if (res.error) {
+      def errorObj = res.error;
+      println """{{error}}${services.localization.render('office365.macro.search.error')} ${errorObj.message}{{/error}}""";
+    }
     for (item in res.value) {
      def docName = item.name;
      def editLink = item.webUrl;
@@ -675,9 +679,14 @@ if (url!=null &amp;&amp; url!="") {
     def docURL = """${driveURL}items/${doc.getValue("id")}"""
     azureAuth.authenticate()
     def res = azureAuth.getGraphApiData(docURL)
-    embedLink = res.get("@microsoft.graph.downloadUrl")
-    println """\n{{pdfviewer file="${embedLink}" width="${width}" height="${height}" /}}\n"""
-    // println services.localization.render('office365.macro.cannotdisplaypdf');
+    if (res.error) {
+      def errorObj = res.error;
+      println """{{error}}${services.localization.render('office365.macro.search.error')} ${errorObj.message}{{/error}}""";
+    } else {
+      embedLink = res.get("@microsoft.graph.downloadUrl")
+      println """\n{{pdfviewer file="${embedLink}" width="${width}" height="${heighft}" /}}\n"""
+      // println services.localization.render('office365.macro.cannotdisplaypdf');
+    }
    } else {
     println """{{html clean=false}}&lt;iframe src="${embedLink}" width="${width}" height="${height}"&gt;&lt;/iframe&gt;{{/html}}"""   
    }

--- a/src/main/resources/Office365/Office365Macro.xml
+++ b/src/main/resources/Office365/Office365Macro.xml
@@ -580,8 +580,7 @@ def showDriveItems(site, query) {
    azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
    if (res!=null) {
     if (res.error) {
-      def errorObj = res.error;
-      println """{{error}}${services.localization.render('office365.macro.search.error')} ${errorObj.message}{{/error}}""";
+      println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.macro.search.error'));
     }
     for (item in res.value) {
      def docName = item.name;
@@ -680,12 +679,11 @@ if (url!=null &amp;&amp; url!="") {
     azureAuth.authenticate()
     def res = azureAuth.getGraphApiData(docURL)
     if (res.error) {
-      def errorObj = res.error;
-      println """{{error}}${services.localization.render('office365.macro.search.error')} ${errorObj.message}{{/error}}""";
+      println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.macro.search.error'));
     } else {
       embedLink = res.get("@microsoft.graph.downloadUrl")
-      println """\n{{pdfviewer file="${embedLink}" width="${width}" height="${heighft}" /}}\n"""
-      // println services.localization.render('office365.macro.cannotdisplaypdf');
+      def pdfViewer = """\n{{pdfviewer file="${embedLink}" width="${width}" height="${heighft}" /}}\n""";
+      println services.rendering.escape(pdfViewer, doc.getSyntax());
     }
    } else {
     println """{{html clean=false}}&lt;iframe src="${embedLink}" width="${width}" height="${height}"&gt;&lt;/iframe&gt;{{/html}}"""   

--- a/src/main/resources/Office365/SitesList.xml
+++ b/src/main/resources/Office365/SitesList.xml
@@ -54,7 +54,10 @@ ${services.localization.render('office365.cannotauthenticate')}
    println "Drive url: ${driveURL}"
  def res = azureAuth.getGraphApiData(driveURL)
  azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
- 
+ if (res.error) {
+   def errorObj = res.error;
+   println """{{error}}${services.localization.render('office365.searchsite.error')} ${errorObj.message}{{/error}}""";
+ }
  for (item in res.value) {
    println """${item.name}=${item.id}"""
   }

--- a/src/main/resources/Office365/SitesList.xml
+++ b/src/main/resources/Office365/SitesList.xml
@@ -55,7 +55,7 @@ ${services.localization.render('office365.cannotauthenticate')}
  def res = azureAuth.getGraphApiData(driveURL)
  azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
  if (res.error) {
-   println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.searchsite.error'));
+   println azureAuth.renderErrorFromResponse(res, 'office365.searchsite.error');
  }
  for (item in res.value) {
    println """${item.name}=${item.id}"""

--- a/src/main/resources/Office365/SitesList.xml
+++ b/src/main/resources/Office365/SitesList.xml
@@ -55,8 +55,7 @@ ${services.localization.render('office365.cannotauthenticate')}
  def res = azureAuth.getGraphApiData(driveURL)
  azureAuth.debug("{{html}}{{{ ${res} }}}{{/html}}")
  if (res.error) {
-   def errorObj = res.error;
-   println """{{error}}${services.localization.render('office365.searchsite.error')} ${errorObj.message}{{/error}}""";
+   println azureAuth.renderErrorFromResponse(res, services.localization.render('office365.searchsite.error'));
  }
  for (item in res.value) {
    println """${item.name}=${item.id}"""

--- a/src/main/resources/Office365/Translations.xml
+++ b/src/main/resources/Office365/Translations.xml
@@ -50,6 +50,7 @@ office365.documentlist.title=Office365 - document list
 office365.documentlist.description=This sample shows a search result on Office365 drive:
 office365.documentlist.searchterm=Search Term
 office365.documentlist.search=Search
+office365.searchsite.error=Error retrieving the SharePoint sites:
 office365.cannotauthenticate=Could not authenticate on Office 365 - [[Clear authentication&gt;&gt;||queryString="clearAuth=1"]]
 office365.macro.cannotdisplaypdf=This macro cannot display a pdf document
 office365.macro.search.description=To insert or change the current Office365 document being embedded, you need to search for it and choose which document to embed. Use the following form to find your document.


### PR DESCRIPTION
Fixed the issue #19 caused by [this](https://github.com/xwikisas/application-office365/commit/4349086b9023a83b7c25f794c02f196281f8aa68) commit where the dependency to Active Directory Authentication Library has been upgraded from `1.2` to `1.6.4` . 

The problem was caused by a call to `AuthenticationResponseParser.parse` that originally, in version `1.2`, received a parameter `params` of type `Map<String,String>`. In the later version, the type of `params` is `Map<String,List<String>>`. 

Besides fixing this, I also improved the display of errors when a call to `MicrosoftGraphAPI` was issued. Originally, if something went wrong, nothing was displayed. Now, a warning block is displayed with the error message of the request response:

![image](https://user-images.githubusercontent.com/45433221/172365360-65441ade-cdc4-468e-880f-2b0ebc206236.png)

![image](https://user-images.githubusercontent.com/45433221/172365097-567a05b5-f7b2-46b9-add3-2cd133833652.png)

I also upgraded the versions for certain XWiki Apps/Macros.
