### PR TITLE
The Office365 application cannot be installed with OpenID Connect version > 2.0.0 #25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,39 @@
       <artifactId>application-licensing-licensor-api</artifactId>
       <version>${licensing.version}</version>
     </dependency>
+    <!-- Because adal4j is an archived repo, as part of https://github.com/xwikisas/application-office365/issues/26
+      we need to move away from it. Until then, some exclusions are added in order to override old dependencies versions
+      that are brought by it or by transitive dependencies. A comment is added for each dependency that should be
+      removed when this migration is done. -->
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>adal4j</artifactId>
       <version>1.6.7</version>
+      <exclusions>
+        <!-- Exclude json-smart because the declared range is lower than the managed one in some cases. See
+          https://github.com/xwikisas/application-office365/issues/25. -->
+        <exclusion>
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- This should be removed once #26 is fixed. -->
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>2.4.11</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- This should be removed once #26 is fixed. -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.xwiki.contrib.showhide</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,45 +51,53 @@
       org.xwiki.rendering.macro.Macro/office365
     </xwiki.extension.components>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <!-- Because adal4j is an archived repo, as part of https://github.com/xwikisas/application-office365/issues/26
+      we need to move away from it. Until then, some exclusions are added in order to override old dependencies versions
+      that are brought by it or by transitive dependencies. A comment is added for each dependency that should be
+      removed when this migration is done. -->
+      <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>adal4j</artifactId>
+        <version>1.6.7</version>
+        <exclusions>
+          <!-- Exclude json-smart because the declared range is lower than the managed one in some cases. See
+            https://github.com/xwikisas/application-office365/issues/25. -->
+          <exclusion>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>2.4.11</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.xwiki.licensing</groupId>
       <artifactId>application-licensing-licensor-api</artifactId>
       <version>${licensing.version}</version>
     </dependency>
-    <!-- Because adal4j is an archived repo, as part of https://github.com/xwikisas/application-office365/issues/26
-      we need to move away from it. Until then, some exclusions are added in order to override old dependencies versions
-      that are brought by it or by transitive dependencies. A comment is added for each dependency that should be
-      removed when this migration is done. -->
+    <!-- This should be removed once #26 is fixed. -->
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>adal4j</artifactId>
-      <version>1.6.7</version>
-      <exclusions>
-        <!-- Exclude json-smart because the declared range is lower than the managed one in some cases. See
-          https://github.com/xwikisas/application-office365/issues/25. -->
-        <exclusion>
-          <groupId>net.minidev</groupId>
-          <artifactId>json-smart</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- This should be removed once #26 is fixed. -->
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.4.11</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- This should be removed once #26 is fixed. -->
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.xwiki.contrib.showhide</groupId>


### PR DESCRIPTION
* exclude json-smart because the declared range is lower than the one managed by oidc authenticator and use a compatible version
* manage some transitive dependencies versions conflicts