### PR TITLE
Installing the Office365 app will make some other apps not-installable #47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,18 @@
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.6.0</version>
     </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>oauth2-oidc-sdk</artifactId>
       <version>11.37.2</version>
+      <exclusions>
+        <!-- Same config as org.xwiki.contrib.oidc -->
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xwiki.contrib.showhide</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
     </dependencies>
@@ -98,6 +102,12 @@
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
+      <version>2.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>oauth2-oidc-sdk</artifactId>
+      <version>11.37.2</version>
     </dependency>
     <dependency>
       <groupId>org.xwiki.contrib.showhide</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,6 @@
       <groupId>com.microsoft.azure</groupId>
       <artifactId>adal4j</artifactId>
     </dependency>
-    <!-- This should be removed once #26 is fixed. -->
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
@@ -115,6 +114,7 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- End remove: This should be removed once #26 is fixed. -->
     <dependency>
       <groupId>org.xwiki.contrib.showhide</groupId>
       <artifactId>showhide-macro</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,20 +68,20 @@
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
-        <version>2.6.0</version>
+        <version>2.4.11</version>
         <exclusions>
           <exclusion>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>oauth2-oidc-sdk</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -107,6 +107,10 @@
       <artifactId>oauth2-oidc-sdk</artifactId>
       <version>11.37.2</version>
       <exclusions>
+        <exclusion>
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
         <!-- Same config as org.xwiki.contrib.oidc -->
         <exclusion>
           <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
* Upgrade `oauth2-oidc-sdk` dependency, which was causing version range issues for json-smart

Since the `com.xwiki.integration-azure-oauth:integration-azure-oauth-ui` depends on `oauth2-oidc-sdk` version 11.37.2 (which doesn't have the version range defined), the issue did not reproduce when installing OIDC then Office365.

~~This PR should also fix the upgrade from 1.13 (#48)~~ It isn't fixed (tested XWiki versions 15.10 and 17.10.9). Upgrading from 1.13 still needs the workaround in https://github.com/xwikisas/application-office365/issues/48#issuecomment-4841886774